### PR TITLE
Fix: don’t assume mode-name is string-valued

### DIFF
--- a/cyphejor.el
+++ b/cyphejor.el
@@ -135,7 +135,7 @@ mode name."
 
 Only do so when the buffer is in fundamental mode."
   (with-current-buffer buffer
-    (when (string= mode-name "Fundamental")
+    (when (and (stringp mode-name) (string= mode-name "Fundamental"))
       (cyphejor--hook))))
 
 ;;;###autoload


### PR DESCRIPTION
‘mode-name’ may also be list-valued and contain ‘mode-line-format’
constructs (e.g. cf. org-agenda), so we need to guard the ‘string=’
invocation.