### PR TITLE
Fix: don’t clobber match-data when running advice

### DIFF
--- a/cyphejor.el
+++ b/cyphejor.el
@@ -136,7 +136,8 @@ mode name."
 Only do so when the buffer is in fundamental mode."
   (with-current-buffer buffer
     (when (eq major-mode 'fundamental-mode)
-      (cyphejor--hook))))
+      (save-match-data
+        (cyphejor--hook)))))
 
 ;;;###autoload
 (define-minor-mode cyphejor-mode


### PR DESCRIPTION
When some command or mode is using match-data and our hook is triggered, e.g.,
from a call to ‘get-buffer-create’, Cyphejor would leave the match-data in a
modified state. This can confuse the caller of ‘get-buffer-create’ the next time
it runs ‘match-string’.

This issue can be reproduced by running ‘(shell-command "ls&")’, which will
raise an error.

We fix this by restoring match-data to its original state.