### PR TITLE
Adjust to upstream change in emacs 28

### DIFF
--- a/cyphejor.el
+++ b/cyphejor.el
@@ -130,7 +130,7 @@ mode name."
          (symbol-name major-mode)
          cyphejor-rules)))
 
-(defun cyphejor--fundamental-mode-advice (buffer)
+(defun cyphejor--fundamental-mode-advice (buffer &optional inhibit-buffer-hooks)
   "Set `mode-name' of BUFFER according to the symbol name in `major-mode'.
 
 Only do so when the buffer is in fundamental mode."


### PR DESCRIPTION
Signature of get-buffer-create has changed in emacs 28 and now this
function also accepts optional argument INHIBIT-BUFFER-HOOKS.

This commit adjust signature of cyphejor--fundamental-mode-advice
to match that of get-buffer-create in emacs 28 without negatively
affecting compatibility of cyphejor-mode with older versions of emacs.