### PR TITLE
Split words in major mode name only by the word-boundary and dash (-) symbols

### DIFF
--- a/cyphejor.el
+++ b/cyphejor.el
@@ -81,7 +81,7 @@ The format of RULES is described in the doc-string of
 
 OLD-NAME must be a string where words are separated with
 punctuation characters."
-  (let ((words    (split-string (downcase old-name) "[[:punct:]]" t))
+  (let ((words    (split-string (downcase old-name) "[\b\\-]+" t))
         (downcase (cl-find :downcase rules))
         (upcase   (cl-find :upcase   rules))
         prefix-words


### PR DESCRIPTION
Hi,

I created this PR related to https://github.com/mrkkrp/cyphejor/issues/12#issuecomment-899303180

Close #12