### PR TITLE
Remove `cyphejor--fundamental-mode-advice`

### DIFF
--- a/cyphejor.el
+++ b/cyphejor.el
@@ -133,18 +133,6 @@ mode name."
          (symbol-name major-mode)
          cyphejor-rules)))
 
-(defun cyphejor--fundamental-mode-advice (buffer &optional _inhibit-buffer-hooks)
-  "Set `mode-name' of BUFFER according to the symbol name in `major-mode'.
-
-Only do so when the buffer is in fundamental mode.
-
-INHIBIT-BUFFER-HOOKS is accepted for compatibility reasons and
-has no effect."
-  (with-current-buffer buffer
-    (when (eq major-mode 'fundamental-mode)
-      (save-match-data
-        (cyphejor--hook)))))
-
 ;;;###autoload
 (define-minor-mode cyphejor-mode
   "Toggle the `cyphejor-mode' minor mode.
@@ -165,11 +153,8 @@ description of the variable for more information."
            'after-change-major-mode-hook
            #'cyphejor--hook)
   (if cyphejor-mode
-      (progn
-        (advice-add 'wdired-change-to-dired-mode :after #'cyphejor--hook)
-        (advice-add 'get-buffer-create :after #'cyphejor--fundamental-mode-advice))
-    (advice-remove 'wdired-change-to-dired-mode #'cyphejor--hook)
-    (advice-remove 'get-buffer-create #'cyphejor--fundamental-mode-advice))
+      (advice-add 'wdired-change-to-dired-mode :after #'cyphejor--hook)
+    (advice-remove 'wdired-change-to-dired-mode #'cyphejor--hook))
   (when cyphejor-mode
     (mapc (lambda (buffer)
             (with-current-buffer buffer


### PR DESCRIPTION
Close #31.

`get-buffer-create` is a primitive and advising primitives is not advisable:

https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Named-Functions.html#index-advice_002dadd

In fact, it changes the nature of `get-buffer-create`:

```
;; before advising
(symbol-function 'get-buffer-create) ==> #<subr get-buffer-create> (subrp (symbol-function 'get-buffer-create)) ==> t ;; after advising
(symbol-function 'get-buffer-create) ==> #[128 "���\"���\"��" [cyphejor--fundamental-mode-advice #<subr get-buffer-create> :after nil apply] 5 advice] (subrp (symbol-function 'get-buffer-create)) ==> nil
```